### PR TITLE
va_list is defined by stdarg.h on solaris

### DIFF
--- a/include/bud/logger.h
+++ b/include/bud/logger.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_BUD_LOGGER_H_
 #define INCLUDE_BUD_LOGGER_H_
 
+#include <stdarg.h>
+
 #include "bud/common.h"
 
 /* Forward declarations */


### PR DESCRIPTION
solves:

```
  CC(target) /home/dave/bud/out/Release/obj.target/bud/src/tracing.o
  ACTION _home_dave_bud_bud_gyp_bud_dtrace_target_bud_dtrace_obj /home/dave/bud/out/Release/obj/gen/bud_provider.o
  TOUCH /home/dave/bud/out/Release/obj.target/bud-dtrace.stamp
  CC(target) /home/dave/bud/out/Release/obj.target/bud/src/avail.o
In file included from ../src/logger.h:4:0,
                 from ../src/client-common.h:7,
                 from ../src/avail.h:6,
                 from ../src/avail.c:3:
../include/bud/logger.h:26:27: error: unknown type name 'va_list'
bud.target.mk:96: recipe for target '/home/dave/bud/out/Release/obj.target/bud/src/avail.o' failed
gmake: *** [/home/dave/bud/out/Release/obj.target/bud/src/avail.o] Error 1
gmake: Leaving directory '/home/dave/bud/out'
```
