### PR TITLE
Readme: Add -g for installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You must have gcc installed. Chances are that you do, but in case you don't:
 Bud can easily be installed using [npm](http://npmjs.org)
 
 ``` bash
-[sudo] npm install bud-tls
+[sudo] npm install -g bud-tls
 ```
 
 This will install the command line tool `bud`.  Optionally, you can build


### PR DESCRIPTION
For a CLI program, global installation should be preferred. Could also add `preferGlobal` to package.json to warn on local installation.
