### PR TITLE
config: piped master config inlined for workers

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -218,7 +218,9 @@ struct bud_config_s {
   bud_config_balance_t balance_e;
 
   /* Options from config file */
-  int inlined;
+  int piped_index;
+  unsigned int piped:1;
+  unsigned int inlined:1;
   char* path;
 
   int worker_count;

--- a/src/master.c
+++ b/src/master.c
@@ -307,8 +307,11 @@ bud_error_t bud_master_spawn_worker(bud_worker_t* worker) {
   bud_error_t err;
   bud_config_t* config;
   int i;
+  int j;
   int r;
+  int aux_argc;
   uv_process_options_t options;
+  char* aux_argv[] = {"--worker", NULL, NULL, NULL};
 
   config = worker->config;
   ASSERT(config != NULL, "Worker config absent");
@@ -335,17 +338,41 @@ bud_error_t bud_master_spawn_worker(bud_worker_t* worker) {
   options.file = config->exepath;
   options.stdio_count = 3;
   options.stdio = calloc(options.stdio_count, sizeof(*options.stdio));
-  options.args = calloc(config->argc + 2, sizeof(*options.args));
+
+  /* config was piped to master's stdin, now inline it for the workers */
+  if (config->piped) {
+    aux_argv[1] = "-i";
+    aux_argv[2] = config->path;
+  }
+
+  aux_argc = ARRAY_SIZE(aux_argv);
+  options.args = calloc(config->argc + aux_argc, sizeof(*options.args));
+
   if (options.stdio == NULL || options.args == NULL) {
     err = bud_error(kBudErrNoMem);
     goto done;
   }
 
-  /* args = { config.argv, "--worker" } */
-  for (i = 0; i < config->argc; i++)
-    options.args[i] = config->argv[i];
-  options.args[i] = "--worker";
-  options.args[i + 1] = NULL;
+  /* Cases:
+   * if piped_index <= 0:
+   *    args = { config.argv, "--worker" }
+   * otherwise:
+   *    args = { config.argv, "--worker", "-i", <config> }
+   */
+  if (config->piped_index <= 0) {
+    for (j = 0; j < config->argc; j++)
+      options.args[j] = config->argv[j];
+  } else {
+    // Goal is to skip piped_index, thus excluding --piped-config argument:
+    for (i = j = 0; i < config->piped_index; i++, j++)
+      options.args[j] = config->argv[i];
+
+    for (i = config->piped_index + 1; i < config->argc; j++, i++)
+      options.args[j] = config->argv[i];
+  }
+
+  for (r = 0; r < aux_argc; r++, j++)
+    options.args[j] = aux_argv[r];
 
   r = uv_timer_init(config->loop, &worker->restart_timer);
   if (r != 0) {


### PR DESCRIPTION
This addresses part 2 of issue #43, instead of using IPC style
of passing in arguments to workers.
- Configuration piped to master gets sent over to the workers
  by means of inlining, by converting their cli argument vectors
  to accept an inlined configuration.
- Ensures that only one config in the set (piped, inline, config) is passed in.
