### PR TITLE
Change SNI/stapling query parameter to url in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ to get the default configuration options (with comments and description below):
     "host": "127.0.0.1",
 
     // %s will be replaced with actual servername
-    "query": "/bud/sni/%s"
+    "url": "/bud/sni/%s"
   },
 
   // OCSP Stapling response loading
@@ -303,7 +303,7 @@ to get the default configuration options (with comments and description below):
     "host": "127.0.0.1",
 
     // %s will be replaced with actual servername
-    "query": "/bud/stapling/%s"
+    "url": "/bud/stapling/%s"
   },
 
   // Secure contexts (i.e. Server Name Indication support)

--- a/default-config.json
+++ b/default-config.json
@@ -32,13 +32,13 @@
     "enabled": false,
     "port": 9000,
     "host": "127.0.0.1",
-    "query": "/bud/sni/%s"
+    "url": "/bud/sni/%s"
   },
   "stapling": {
     "enabled": false,
     "port": 9000,
     "host": "127.0.0.1",
-    "query": "/bud/stapling/%s"
+    "url": "/bud/stapling/%s"
   },
   "contexts": []
 }


### PR DESCRIPTION
The "query" parameter does not exist, it is named "url".

Just a small change to the README and default-config