### PR TITLE
Check for client NULL pointer

### DIFF
--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -259,7 +259,7 @@ int bud_client_stapling_cb(SSL* ssl, void* arg) {
   bud_client_t* client;
 
   client = SSL_get_ex_data(ssl, kBudSSLClientIndex);
-  if (client->stapling_ocsp_resp == NULL)
+  if (client == NULL || client->stapling_ocsp_resp == NULL)
     return SSL_TLSEXT_ERR_NOACK;
 
   SSL_set_tlsext_status_ocsp_resp(ssl,


### PR DESCRIPTION
The `client` pointer in the `bud_client_stapling_cb` could be null while derefencing.

Found by/with facebook infer

src/ocsp.c:262: error: NULL_DEREFERENCE
   pointer client last assigned on line 261 could be null and is dereferenced at line 262, column 7