### PR TITLE
Fix SNI use after free

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1201,7 +1201,6 @@ bud_client_error_t bud_client_on_hello(bud_client_t* client) {
                                    client->hello.servername_len,
                                    bud_client_sni_cb,
                                    &err);
-    client->sni_req->data = client;
     if (!bud_is_ok(err)) {
       NOTICE(&client->frontend,
              "failed to request SNI: \"%s\"",
@@ -1209,6 +1208,7 @@ bud_client_error_t bud_client_on_hello(bud_client_t* client) {
       goto fatal;
     }
 
+    client->sni_req->data = client;
     client->async_hello = kBudProgressRunning;
   /* Perform OCSP stapling request */
   } else if (config->stapling.enabled && client->hello.ocsp_request != 0) {

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -66,11 +66,11 @@ bud_error_t bud_client_ocsp_stapling(bud_client_t* client) {
                                             id_size,
                                             bud_client_stapling_cache_req_cb,
                                             &err);
-  client->stapling_cache_req->data = client;
 
   if (!bud_is_ok(err))
     goto fatal;
 
+  client->stapling_cache_req->data = client;
   client->async_hello = kBudProgressRunning;
   return bud_ok();
 
@@ -155,11 +155,11 @@ void bud_client_stapling_cache_req_cb(bud_http_request_t* req,
                                        json_size - 1,
                                        bud_client_stapling_req_cb,
                                        &err);
-  client->stapling_req->data = client;
 
   if (!bud_is_ok(err))
     goto done;
 
+  client->stapling_req->data = client;
   client->async_hello = kBudProgressRunning;
 
 done:


### PR DESCRIPTION
When the SNI request fails the client->sni_req is free'd in a callback in bud_http_get but then accessed from bud_client_on_hello even in case of an error.
