### PR TITLE
[deps] bump asn1.js, ocsp for Node 5.x; remove utile dep in prod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 sudo: false
 node_js:
+  - "5"
+  - "4"
   - "0.12"
 branches:
   only:

--- a/lib/bud.js
+++ b/lib/bud.js
@@ -2,7 +2,6 @@ var assert = require('assert');
 var path = require('path');
 var spawn = require('child_process').spawn;
 var util = require('util');
-var utile = require('utile');
 var EventEmitter = require('events').EventEmitter;
 
 var binary = path.resolve(__dirname, '..', 'bin', 'bud');
@@ -10,7 +9,7 @@ var binary = path.resolve(__dirname, '..', 'bin', 'bud');
 function Server(options) {
   EventEmitter.call(this);
 
-  this.options = options ? utile.clone(options) : {};
+  this.options = options ? util._extend({}, options) : {};
   this.proc = null;
 }
 util.inherits(Server, EventEmitter);

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "homepage": "https://github.com/indutny/bud",
   "devDependencies": {
-    "asn1.js": "^2.0.3",
-    "asn1.js-rfc2560": "^2.1.0",
-    "mocha": "^1.18.2",
-    "ocsp": "^1.0.0",
-    "semver": "^2.2.1",
-    "spdy": "^2.1.0",
-    "utile": "^0.2.1"
+    "asn1.js": "^4.5.2",
+    "asn1.js-rfc2560": "^4.0.0",
+    "mocha": "^2.4.5",
+    "ocsp": "^1.0.3",
+    "semver": "^5.1.0",
+    "spdy": "^3.2.3",
+    "utile": "^0.3.0"
   }
 }


### PR DESCRIPTION
I was testing today the updated bud node module.  I discovered on a fresh install of bud from npm, bud is missing **utile** package when required as module.  With this change, bud can remain without any required external dependencies for production.